### PR TITLE
PB-984: Legger til støtte for POST kall til dittnav-api

### DIFF
--- a/src/main/kotlin/no/nav/tms/min/side/proxy/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/config/bootstrap.kt
@@ -25,6 +25,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
         host(environment.corsAllowedOrigins)
         allowCredentials = true
         header(HttpHeaders.ContentType)
+        method(HttpMethod.Options)
     }
 
     install(ContentNegotiation) {

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/config/httpClient.kt
@@ -15,4 +15,14 @@ suspend inline fun <reified T> HttpClient.get(url: String, accessToken: AccessTo
     }
 }
 
+suspend inline fun <reified T> HttpClient.post(url: String, content: String, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
+    request {
+        url(url)
+        method = HttpMethod.Post
+        header(HttpHeaders.Authorization, "Bearer ${accessToken.value}")
+        contentType(ContentType.Application.Json)
+        body = content
+    }
+}
+
 

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/config/httpClient.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonElement
 import no.nav.tms.min.side.proxy.common.AccessToken
 
 suspend inline fun <reified T> HttpClient.get(url: String, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
@@ -15,7 +16,7 @@ suspend inline fun <reified T> HttpClient.get(url: String, accessToken: AccessTo
     }
 }
 
-suspend inline fun <reified T> HttpClient.post(url: String, content: String, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
+suspend inline fun <reified T> HttpClient.post(url: String, content: JsonElement, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
     request {
         url(url)
         method = HttpMethod.Post

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/DittnavConsumer.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/DittnavConsumer.kt
@@ -2,6 +2,7 @@ package no.nav.tms.min.side.proxy.dittnav
 
 import io.ktor.client.*
 import io.ktor.client.statement.*
+import kotlinx.serialization.json.JsonElement
 import no.nav.tms.min.side.proxy.common.AccessToken
 import no.nav.tms.min.side.proxy.common.TokenFetcher
 import no.nav.tms.min.side.proxy.config.get
@@ -21,7 +22,7 @@ class DittnavConsumer(
         return httpClient.get(url, accessToken)
     }
 
-    suspend fun postContent(user: IdportenUser, content: String, proxyPath: String?): HttpResponse {
+    suspend fun postContent(user: IdportenUser, content: JsonElement, proxyPath: String?): HttpResponse {
         val accessToken = AccessToken(tokenFetcher.getDittnavApiToken(user.tokenString))
         val url = "$baseUrl/$proxyPath"
 

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/DittnavConsumer.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/DittnavConsumer.kt
@@ -5,6 +5,7 @@ import io.ktor.client.statement.*
 import no.nav.tms.min.side.proxy.common.AccessToken
 import no.nav.tms.min.side.proxy.common.TokenFetcher
 import no.nav.tms.min.side.proxy.config.get
+import no.nav.tms.min.side.proxy.config.post
 import no.nav.tms.token.support.idporten.sidecar.user.IdportenUser
 
 class DittnavConsumer(
@@ -18,6 +19,13 @@ class DittnavConsumer(
         val url = "$baseUrl/$proxyPath"
 
         return httpClient.get(url, accessToken)
+    }
+
+    suspend fun postContent(user: IdportenUser, content: String, proxyPath: String?): HttpResponse {
+        val accessToken = AccessToken(tokenFetcher.getDittnavApiToken(user.tokenString))
+        val url = "$baseUrl/$proxyPath"
+
+        return httpClient.post(url, content, accessToken)
     }
 
 }

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/dittnavApi.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/dittnavApi.kt
@@ -7,6 +7,7 @@ import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.pipeline.*
+import no.nav.tms.min.side.proxy.config.jsonConfig
 import no.nav.tms.token.support.idporten.sidecar.user.IdportenUser
 import no.nav.tms.token.support.idporten.sidecar.user.IdportenUserFactory
 import org.slf4j.LoggerFactory
@@ -31,7 +32,7 @@ fun Route.dittnavApi(consumer: DittnavConsumer) {
         val proxyPath = call.parameters["proxyPath"]
 
         try {
-            val content = call.receiveText()
+            val content = jsonConfig().parseToJsonElement(call.receiveText())
             log.info("Content: $content")
             val response = consumer.postContent(authenticatedUser, content, proxyPath)
             call.respond(response.status)

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/dittnavApi.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/dittnavApi.kt
@@ -32,6 +32,7 @@ fun Route.dittnavApi(consumer: DittnavConsumer) {
 
         try {
             val content = call.receiveText()
+            log.info("Content: $content")
             val response = consumer.postContent(authenticatedUser, content, proxyPath)
             call.respond(response.status)
         } catch (exception: Exception) {
@@ -39,7 +40,6 @@ fun Route.dittnavApi(consumer: DittnavConsumer) {
             call.respond(HttpStatusCode.ServiceUnavailable)
         }
     }
-
 }
 
 private val PipelineContext<Unit, ApplicationCall>.authenticatedUser: IdportenUser

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/dittnavApi.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/dittnavApi.kt
@@ -3,6 +3,7 @@ package no.nav.tms.min.side.proxy.dittnav
 import io.ktor.application.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.ktor.request.*
 import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.pipeline.*
@@ -22,6 +23,19 @@ fun Route.dittnavApi(consumer: DittnavConsumer) {
             call.respond(response.status, response.readBytes())
         } catch (exception: Exception) {
             log.warn("Klarte ikke hente data fra '$proxyPath'. Feilmelding: ${exception.message}", exception)
+            call.respond(HttpStatusCode.ServiceUnavailable)
+        }
+    }
+
+    post("/dittnav/{proxyPath}") {
+        val proxyPath = call.parameters["proxyPath"]
+
+        try {
+            val content = call.receiveText()
+            val response = consumer.postContent(authenticatedUser, content, proxyPath)
+            call.respond(response.status)
+        } catch (exception: Exception) {
+            log.warn("Klarte ikke poste data. Feilmelding: ${exception.message}", exception)
             call.respond(HttpStatusCode.ServiceUnavailable)
         }
     }

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/dittnavApi.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/dittnav/dittnavApi.kt
@@ -33,7 +33,6 @@ fun Route.dittnavApi(consumer: DittnavConsumer) {
 
         try {
             val content = jsonConfig().parseToJsonElement(call.receiveText())
-            log.info("Content: $content")
             val response = consumer.postContent(authenticatedUser, content, proxyPath)
             call.respond(response.status)
         } catch (exception: Exception) {


### PR DESCRIPTION
For å holde det så enkelt som mulig så brukes call.receiveText() for å hente innholdet fra POST-kallet og det parses videre til et JsonElement. Ved  feil vil det kastes en SerializationException, feilhåndteringen kan evt. forbedres i en ny pull-request.

PB-984: Legger til støtte for POST kall til dittnav-api