### PR TITLE
Bytter til å bruke www.dev.nav.no og www.nav.no i ingressene

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -30,7 +30,7 @@ spec:
     max: 4
   webproxy: true
   ingresses:
-    - "https://person.dev.nav.no/tms-min-side-proxy"
+    - "https://www.dev.nav.no/tms-min-side-proxy"
   resources:
     limits:
       cpu: "3"

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -30,7 +30,7 @@ spec:
     max: 4
   webproxy: true
   ingresses:
-    - "https://person.intern.nav.no/tms-min-side-proxy"
+    - "https://www.intern.nav.no/tms-min-side-proxy"
   resources:
     limits:
       cpu: "3"


### PR DESCRIPTION
Bytter til å bruke www.dev.nav.no og www.nav.no i ingressene, slik at det blir lettere å kalle min-side-proxy fra mikrofrontends som har satt custom headere.  Når man bruker `credendials: include` i kall fra mikrofrontends så må man whiteliste headere som ikke er cors-whitelistet i min-side-proxy. Dette unngår man hvis man setter `credentials: same-site` og ligger på samme origin.