### PR TITLE
Legger til et nytt tokenx endepunkt for personalia

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(TmsKtorTokenSupport.tokendingsExchange)
     implementation(TmsKtorTokenSupport.idportenSidecar)
     implementation(TmsKtorTokenSupport.azureExchange)
+    implementation(TmsKtorTokenSupport.tokenXValidation)
     implementation(Logstash.logbackEncoder)
     implementation(Micrometer.registryPrometheus)
     implementation(Prometheus.common)
@@ -67,6 +68,7 @@ dependencies {
     testImplementation(Jjwt.api)
     testImplementation(Mockk.mockk)
     testImplementation(TmsKtorTokenSupport.idportenSidecarMock)
+    testImplementation(TmsKtorTokenSupport.tokenXValidationMock)
     testImplementation(TmsCommonLib.testutils)
 }
 

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -43,6 +43,9 @@ spec:
       cpu: "20m"
       memory: 128Mi
   accessPolicy:
+    inbound:
+      rules:
+        - application: tms-min-side-proxy
     outbound:
       external:
         - host: veilarboppfolging.dev-fss-pub.nais.io

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -45,7 +45,7 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: tms-min-side-proxy
+        - application: tms-min-side
     outbound:
       external:
         - host: veilarboppfolging.dev-fss-pub.nais.io

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -43,7 +43,7 @@ spec:
   accessPolicy:
     inbound:
       rules:
-        - application: tms-min-side-proxy
+        - application: tms-min-side
     outbound:
       external:
         - host: veilarboppfolging.prod-fss-pub.nais.io

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -41,6 +41,9 @@ spec:
       cpu: "50m"
       memory: 256Mi
   accessPolicy:
+    inbound:
+      rules:
+        - application: tms-min-side-proxy
     outbound:
       external:
         - host: veilarboppfolging.prod-fss-pub.nais.io

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/Application.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/Application.kt
@@ -16,6 +16,7 @@ import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import no.nav.tms.common.util.config.StringEnvVar
 import no.nav.tms.min.side.proxy.personalia.NavnFetcher
+import no.nav.tms.min.side.proxy.personalia.PersonaliaFetcher
 import no.nav.tms.token.support.azure.exchange.AzureServiceBuilder
 import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
 
@@ -93,6 +94,14 @@ data class AppConfiguration(
         pdlBehandlingsnummer,
         tokendingsService
     )
+
+    val personaliaFetcher = PersonaliaFetcher(
+        httpClient,
+        pdlApiUrl,
+        pdlApiClientId,
+        pdlBehandlingsnummer,
+        tokendingsService
+    )
 }
 
 fun ObjectMapper.jsonConfig() {
@@ -110,6 +119,7 @@ fun ApplicationEngineEnvironmentBuilder.envConfig(appConfig: AppConfiguration) {
             contentFetcher = appConfig.contentFecther,
             externalContentFetcher = appConfig.externalContentFetcher,
             navnFetcher = appConfig.navnFetcher,
+            personaliaFetcher = appConfig.personaliaFetcher,
             unleash = setupUnleash(
                 unleashApiUrl = appConfig.unleashServerApiUrl,
                 unleashApiKey = appConfig.unleashServerApiToken,

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/PersonaliaFetcher.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/PersonaliaFetcher.kt
@@ -8,11 +8,11 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import no.nav.tms.token.support.idporten.sidecar.user.IdportenUser
 import no.nav.tms.token.support.tokendings.exchange.TokendingsService
+import no.nav.tms.token.support.tokenx.validation.user.TokenXUser
 import java.time.Duration
 
-class NavnFetcher(
+class PersonaliaFetcher(
     private val client: HttpClient,
     private val pdlUrl: String,
     private val pdlClientId: String,
@@ -28,13 +28,13 @@ class NavnFetcher(
     private val log = KotlinLogging.logger {}
     private val securelog = KotlinLogging.logger("secureLog")
 
-    fun getNavn(user: IdportenUser): String {
+    fun getNavn(user: TokenXUser): String {
         return cache.get(user.ident) {
             fetchNavn(user)
         }
     }
 
-    private fun fetchNavn(user: IdportenUser): String = runBlocking(Dispatchers.IO) {
+    private fun fetchNavn(user: TokenXUser): String = runBlocking(Dispatchers.IO) {
         tokendingsService.exchangeToken(user.tokenString, pdlClientId)
             .let { token -> queryForNavn(user.ident, token) }
             .let { response -> checkForErrors(response) }
@@ -74,56 +74,5 @@ class NavnFetcher(
 
         return response.data?: throw HentNavnException("Ingen data i graphql-svar.")
     }
-}
-
-class HentNavnException(message: String, cause: Exception? = null): Exception(message, cause)
-
-class HentNavn(ident: String) {
-    val query = """
-        query(${'$'}ident: ID!) {
-            hentPerson(ident: ${'$'}ident) {
-                navn {
-                    fornavn,
-                    mellomnavn,
-                    etternavn
-                }
-            }
-        }
-    """.compactJson()
-
-    val variables = mapOf(
-        "ident" to ident
-    )
-}
-
-fun String.compactJson(): String =
-    trimIndent()
-        .replace("\r", " ")
-        .replace("\n", " ")
-        .replace("\\s+".toRegex(), " ")
-
-data class HentNavnResponse(
-    val data: HentNavnData?,
-    val errors: List<Map<String, Any>>?
-) {
-    data class HentNavnData(
-        val hentPerson: Person
-    )
-
-    data class Person (
-        val navn: List<Navn>
-    ) {
-        val fullnavn = navn.first().let {
-            listOf(it.fornavn, it.mellomnavn, it.etternavn)
-                .filter { navn -> !navn.isNullOrBlank() }
-                .joinToString(" ")
-        }
-    }
-
-    data class Navn(
-        val fornavn: String,
-        val mellomnavn: String? = null,
-        val etternavn: String,
-    )
 }
 

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/navnRoutes.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/navnRoutes.kt
@@ -26,10 +26,10 @@ fun Route.navnRoutes(navnFetcher: NavnFetcher) {
     }
 }
 
-private data class Navn(val navn: String)
-private data class Ident(val ident: String)
+data class Navn(val navn: String)
+data class Ident(val ident: String)
 
-private data class NavnAndIdent(
+data class NavnAndIdent(
     val navn: String?,
     val ident: String
 )

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/personaliaRoutes.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/personaliaRoutes.kt
@@ -1,5 +1,6 @@
 package no.nav.tms.min.side.proxy.personalia
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -7,11 +8,15 @@ import io.ktor.util.pipeline.*
 import no.nav.tms.token.support.tokenx.validation.user.TokenXUserFactory
 
 fun Route.personaliaRoutes(personaliaFetcher: PersonaliaFetcher) {
+    val log = KotlinLogging.logger {}
+
     get("/personalia") {
         try {
+            log.info { "Inside personalia route" }
             personaliaFetcher.getNavn(user)
                 .let { navn -> call.respond(NavnAndIdent(navn, user.ident)) }
         } catch (e: HentNavnException) {
+            log.error { "Failed to fetch personalia" }
             call.respond(NavnAndIdent(navn = null, ident = user.ident))
         }
     }

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/personaliaRoutes.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/personaliaRoutes.kt
@@ -1,6 +1,5 @@
 package no.nav.tms.min.side.proxy.personalia
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -8,15 +7,11 @@ import io.ktor.util.pipeline.*
 import no.nav.tms.token.support.tokenx.validation.user.TokenXUserFactory
 
 fun Route.personaliaRoutes(personaliaFetcher: PersonaliaFetcher) {
-    val log = KotlinLogging.logger {}
-
     get("/personalia") {
         try {
-            log.info { "Inside personalia route" }
             personaliaFetcher.getNavn(user)
                 .let { navn -> call.respond(NavnAndIdent(navn, user.ident)) }
         } catch (e: HentNavnException) {
-            log.error { "Failed to fetch personalia" }
             call.respond(NavnAndIdent(navn = null, ident = user.ident))
         }
     }

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/personaliaRoutes.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/personalia/personaliaRoutes.kt
@@ -1,0 +1,21 @@
+package no.nav.tms.min.side.proxy.personalia
+
+import io.ktor.server.application.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.util.pipeline.*
+import no.nav.tms.token.support.tokenx.validation.user.TokenXUserFactory
+
+fun Route.personaliaRoutes(personaliaFetcher: PersonaliaFetcher) {
+    get("/personalia") {
+        try {
+            personaliaFetcher.getNavn(user)
+                .let { navn -> call.respond(NavnAndIdent(navn, user.ident)) }
+        } catch (e: HentNavnException) {
+            call.respond(NavnAndIdent(navn = null, ident = user.ident))
+        }
+    }
+}
+
+private val PipelineContext<Unit, ApplicationCall>.user
+    get() = TokenXUserFactory.createTokenXUser(call)

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/proxyApi.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/proxyApi.kt
@@ -41,9 +41,6 @@ fun Application.proxyApi(
                 setAsDefault = true
                 levelOfAssurance = SUBSTANTIAL
             }
-            tokenX {
-                setAsDefault = false
-            }
         }
         install(IdPortenLogin)
     },

--- a/src/test/kotlin/no/nav/tms/min/side/proxy/GetRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/min/side/proxy/GetRoutesTest.kt
@@ -49,7 +49,8 @@ class GetRoutesTest {
         mockApi(
             contentFetcher = contentFecther(proxyHttpClient),
             externalContentFetcher = externalContentFetcher(proxyHttpClient),
-            navnFetcher = mockk()
+            navnFetcher = mockk(),
+            personaliaFetcher = mockk()
         )
 
         initExternalServices(
@@ -96,7 +97,8 @@ class GetRoutesTest {
         mockApi(
             contentFetcher = contentFecther(proxyHttpClient),
             externalContentFetcher = externalContentFetcher(proxyHttpClient),
-            navnFetcher = mockk()
+            navnFetcher = mockk(),
+            personaliaFetcher = mockk()
         )
 
         initExternalServices(
@@ -129,7 +131,8 @@ class GetRoutesTest {
         mockApi(
             contentFetcher = contentFecther(proxyHttpClient),
             externalContentFetcher = externalContentFetcher(proxyHttpClient),
-            navnFetcher = mockk()
+            navnFetcher = mockk(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/internal/isAlive").status shouldBe HttpStatusCode.OK
@@ -148,7 +151,8 @@ class GetRoutesTest {
             contentFetcher = contentFecther(proxyHttpClient),
             externalContentFetcher = externalContentFetcher(proxyHttpClient),
             unleash = unleash,
-            navnFetcher = mockk()
+            navnFetcher = mockk(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/featuretoggles").assert {
@@ -159,7 +163,12 @@ class GetRoutesTest {
 
     @Test
     fun authPing() = testApplication {
-        mockApi(contentFetcher = mockk(), externalContentFetcher = mockk(), navnFetcher = mockk())
+        mockApi(
+            contentFetcher = mockk(),
+            externalContentFetcher = mockk(),
+            navnFetcher = mockk(),
+            personaliaFetcher = mockk()
+        )
         client.get("/authPing").status shouldBe HttpStatusCode.OK
     }
 
@@ -170,6 +179,7 @@ class GetRoutesTest {
                 contentFetcher = mockk(),
                 externalContentFetcher = mockk(),
                 navnFetcher = mockk(),
+                personaliaFetcher = mockk(),
                 levelOfAssurance = LevelOfAssurance.SUBSTANTIAL
             )
 

--- a/src/test/kotlin/no/nav/tms/min/side/proxy/PostRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/min/side/proxy/PostRoutesTest.kt
@@ -21,7 +21,8 @@ class PostRoutesTest {
         mockApi(
             contentFetcher = contentFecther(proxyHttpClient),
             externalContentFetcher = externalContentFetcher(proxyHttpClient),
-            navnFetcher = mockk()
+            navnFetcher = mockk(),
+            personaliaFetcher = mockk()
         )
 
         initExternalServices(

--- a/src/test/kotlin/no/nav/tms/min/side/proxy/personalia/NavnRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/min/side/proxy/personalia/NavnRoutesTest.kt
@@ -61,7 +61,8 @@ class NavnRoutesTest {
         mockApi(
             contentFetcher = mockk(),
             externalContentFetcher = mockk(),
-            navnFetcher = navnFetcher()
+            navnFetcher = navnFetcher(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/personalia/navn").let {
@@ -90,7 +91,8 @@ class NavnRoutesTest {
         mockApi(
             contentFetcher = mockk(),
             externalContentFetcher = mockk(),
-            navnFetcher = navnFetcher()
+            navnFetcher = navnFetcher(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/personalia/navn").let {
@@ -117,7 +119,8 @@ class NavnRoutesTest {
         mockApi(
             contentFetcher = mockk(),
             externalContentFetcher = mockk(),
-            navnFetcher = navnFetcher()
+            navnFetcher = navnFetcher(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/personalia/navn").let {
@@ -141,7 +144,8 @@ class NavnRoutesTest {
         mockApi(
             contentFetcher = mockk(),
             externalContentFetcher = mockk(),
-            navnFetcher = navnFetcher()
+            navnFetcher = navnFetcher(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/personalia/navn").let {
@@ -165,7 +169,8 @@ class NavnRoutesTest {
         mockApi(
             contentFetcher = mockk(),
             externalContentFetcher = mockk(),
-            navnFetcher = navnFetcher()
+            navnFetcher = navnFetcher(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/personalia/ident").let {
@@ -196,7 +201,8 @@ class NavnRoutesTest {
         mockApi(
             contentFetcher = mockk(),
             externalContentFetcher = mockk(),
-            navnFetcher = navnFetcher()
+            navnFetcher = navnFetcher(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/navn").let {
@@ -226,7 +232,8 @@ class NavnRoutesTest {
         mockApi(
             contentFetcher = mockk(),
             externalContentFetcher = mockk(),
-            navnFetcher = navnFetcher()
+            navnFetcher = navnFetcher(),
+            personaliaFetcher = mockk()
         )
 
         client.get("/navn").let {

--- a/src/test/kotlin/no/nav/tms/min/side/proxy/testApplication.kt
+++ b/src/test/kotlin/no/nav/tms/min/side/proxy/testApplication.kt
@@ -22,10 +22,13 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.mockk.coEvery
 import io.mockk.mockk
 import no.nav.tms.min.side.proxy.personalia.NavnFetcher
+import no.nav.tms.min.side.proxy.personalia.PersonaliaFetcher
 import no.nav.tms.token.support.azure.exchange.AzureService
 import no.nav.tms.token.support.idporten.sidecar.mock.LevelOfAssurance
 import no.nav.tms.token.support.idporten.sidecar.mock.idPortenMock
 import no.nav.tms.token.support.tokendings.exchange.TokendingsService
+import no.nav.tms.token.support.tokenx.validation.mock.tokenXMock
+import no.nav.tms.token.support.tokenx.validation.mock.LevelOfAssurance as LevelOfAssuranceTokenX
 import java.lang.IllegalArgumentException
 
 private const val testIssuer = "test-issuer"
@@ -38,6 +41,7 @@ internal fun ApplicationTestBuilder.mockApi(
     contentFetcher: ContentFetcher,
     externalContentFetcher: ExternalContentFetcher,
     navnFetcher: NavnFetcher,
+    personaliaFetcher: PersonaliaFetcher,
     levelOfAssurance: LevelOfAssurance = LevelOfAssurance.LEVEL_4,
     unleash: Unleash = FakeUnleash()
 ) = application {
@@ -56,7 +60,18 @@ internal fun ApplicationTestBuilder.mockApi(
                 }
             }
         },
+        tokenXAuthInstaller = {
+            authentication {
+                tokenXMock {
+                    alwaysAuthenticated = true
+                    setAsDefault = false
+                    staticLevelOfAssurance = LevelOfAssuranceTokenX.LEVEL_4
+                    staticUserPid = "12345"
+                }
+            }
+        },
         navnFetcher = navnFetcher,
+        personaliaFetcher = personaliaFetcher,
         unleash = unleash
     )
 }


### PR DESCRIPTION
Legger til et nytt tokenx endepunkt for personalia slik at det blir mulig for Min side å hente navn og ident Server-side. Når Idporten routen ikke lenger brukes så kan vi fjerne `navnFetcher.kt` og `navnRoutes.kt`