### PR TITLE
Fjerner utkast route

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -56,7 +56,6 @@ spec:
         - host: min-side-unleash-api.nav.cloud.nais.io
         - host: pdl-api.dev-fss-pub.nais.io
       rules:
-        - application: tms-utkast
         - application: tms-mikrofrontend-selector
         - application: meldekort-api-q2
           namespace: meldekort
@@ -78,10 +77,6 @@ spec:
       value: http://tms-mikrofrontend-selector
     - name: SELCTOR_CLIENT_ID
       value: dev-gcp:min-side:tms-mikrofrontend-selector
-    - name: UTKAST_BASE_URL
-      value: http://tms-utkast
-    - name: UTKAST_CLIENT_ID
-      value: dev-gcp:min-side:tms-utkast
     - name: OPPFOLGING_API_URL
       value: http://veilarboppfolging.poao/veilarboppfolging
     - name: OPPFOLGING_CLIENT_ID

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -54,7 +54,6 @@ spec:
         - host: min-side-unleash-api.nav.cloud.nais.io
         - host: pdl-api.prod-fss-pub.nais.io
       rules:
-        - application: tms-utkast
         - application: tms-mikrofrontend-selector
         - application: meldekort-api
           namespace: meldekort
@@ -80,10 +79,6 @@ spec:
       value: http://tms-mikrofrontend-selector
     - name: SELCTOR_CLIENT_ID
       value: prod-gcp:min-side:tms-mikrofrontend-selector
-    - name: UTKAST_BASE_URL
-      value: http://tms-utkast
-    - name: UTKAST_CLIENT_ID
-      value: prod-gcp:min-side:tms-utkast
     - name: OPPFOLGING_API_URL
       value: http://veilarboppfolging.poao/veilarboppfolging
     - name: OPPFOLGING_CLIENT_ID

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/Application.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/Application.kt
@@ -32,8 +32,6 @@ data class AppConfiguration(
     val corsAllowedSchemes: String = StringEnvVar.getEnvVar("CORS_ALLOWED_SCHEMES"),
      private val meldekortClientId: String = StringEnvVar.getEnvVar("MELDEKORT_CLIENT_ID"),
     private val meldekortBaseUrl: String = StringEnvVar.getEnvVar("MELDEKORT_BASE_URL"),
-    private val utkastClientId: String = StringEnvVar.getEnvVar("UTKAST_CLIENT_ID"),
-    private val utkastBaseUrl: String = StringEnvVar.getEnvVar("UTKAST_BASE_URL"),
     private val selectorClientId: String = StringEnvVar.getEnvVar("SELCTOR_CLIENT_ID"),
     private val selectorBaseUrl: String = StringEnvVar.getEnvVar("SELCTOR_BASE_URL"),
     private val oppfolgingClientId: String = StringEnvVar.getEnvVar("OPPFOLGING_CLIENT_ID"),
@@ -67,8 +65,6 @@ data class AppConfiguration(
 
     val contentFecther = ContentFetcher(
         proxyHttpClient = proxyHttpClient,
-        utkastClientId = utkastClientId,
-        utkastBaseUrl = utkastBaseUrl,
         selectorClientId = selectorClientId,
         selectorBaseUrl = selectorBaseUrl,
         oppfolgingClientId = oppfolgingClientId,

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/ContentFetcher.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/ContentFetcher.kt
@@ -4,21 +4,11 @@ import io.ktor.client.statement.*
 
 class ContentFetcher(
     private val proxyHttpClient: ProxyHttpClient,
-    private val utkastClientId: String,
-    private val utkastBaseUrl: String,
     private val selectorClientId: String,
     private val selectorBaseUrl: String,
     private val oppfolgingClientId: String,
     private val oppfolgingBaseUrl: String
 ) {
-    suspend fun getUtkastContent(token: String, proxyPath: String?): HttpResponse =
-        proxyHttpClient.getContent(
-            userToken = token,
-            targetAppId = utkastClientId,
-            baseUrl = utkastBaseUrl,
-            proxyPath = proxyPath,
-            requestTimeoutAfter = 8250
-        )
 
     suspend fun getProfilContent(token: String, proxyPath: String?): HttpResponse =
         proxyHttpClient.getContent(

--- a/src/main/kotlin/no/nav/tms/min/side/proxy/proxyRoutes.kt
+++ b/src/main/kotlin/no/nav/tms/min/side/proxy/proxyRoutes.kt
@@ -14,11 +14,6 @@ private val log = KotlinLogging.logger {}
 private val securelog = KotlinLogging.logger("secureLog")
 fun Route.proxyRoutes(contentFetcher: ContentFetcher, externalContentFetcher: ExternalContentFetcher) {
 
-    get("/utkast/{proxyPath...}") {
-        val response = contentFetcher.getUtkastContent(accessToken, proxyPath)
-        call.respondBytes(response.readRawBytes(), response.contentType(), response.status)
-    }
-
     get("/meldekort/{proxyPath...}") {
         val response = externalContentFetcher.getMeldekortContent(accessToken, proxyPath)
         call.respondBytes(response.readRawBytes(), response.contentType(), response.status)

--- a/src/test/kotlin/no/nav/tms/min/side/proxy/GetRoutesTest.kt
+++ b/src/test/kotlin/no/nav/tms/min/side/proxy/GetRoutesTest.kt
@@ -21,7 +21,6 @@ class GetRoutesTest {
     private val testParametersMap =
         mapOf(
             "meldekort" to TestParameters("http://meldekort.test"),
-            "utkast" to TestParameters("http://utkast.test"),
             "personalia" to TestParameters("http://personalia.test"),
             "selector" to TestParameters("http://selector.test"),
             "oppfolging" to TestParameters("http://veilarboppfolging.test"),
@@ -38,7 +37,7 @@ class GetRoutesTest {
 
 
     @ParameterizedTest
-    @ValueSource(strings = [ "utkast", "meldekort", "selector", "aia"])
+    @ValueSource(strings = ["meldekort", "selector", "aia"])
     fun `proxy get api`(tjenestePath: String) = testApplication {
         val applicationhttpClient = testApplicationHttpClient()
         val proxyHttpClient = ProxyHttpClient(applicationhttpClient, tokendigsMock, azureMock)
@@ -189,8 +188,6 @@ class GetRoutesTest {
 
     private fun contentFecther(proxyHttpClient: ProxyHttpClient): ContentFetcher = ContentFetcher(
         proxyHttpClient = proxyHttpClient,
-        utkastClientId = "utkastclient",
-        utkastBaseUrl = testParametersMap.getParameters("utkast").baseUrl,
         selectorClientId = "selector",
         selectorBaseUrl = testParametersMap.getParameters("selector").baseUrl,
         oppfolgingBaseUrl = testParametersMap.getParameters("oppfolging").baseUrl,


### PR DESCRIPTION
Min side henter utkast server-side rett fra tms-utkast, derfor trengs ikke denne routen lenger.